### PR TITLE
Use "is_linux" to wrap the Linux specific changes, and add zfs_destro…

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
@@ -144,62 +144,66 @@ function test_n_check
 		*)	log_fail "Unsupported dataset: '$dtst'."
 	esac
 
-        # Kill any lingering instances of mkbusy, and clear the list.
-	[[ -z $pidlist ]] || log_must $KILL -TERM $pidlist
-	pidlist=""
-	log_mustnot $PGREP -fl $MKBUSY
-	
 	# Firstly, umount ufs filesystem which was created by zfs volume.
 	if is_global_zone; then
 		log_must $UMOUNT -f $TESTDIR1
 	fi
 
 	# Invoke 'zfs destroy [-rRf] <dataset>'
-	log_must $ZFS destroy $opt $dtst
+	if ! is_linux ; then
+	        log_must $ZFS destroy $opt $dtst
+	fi
+	
+	# Kill any lingering instances of mkbusy, and clear the list.
+	[[ -z $pidlist ]] || log_must $KILL -TERM $pidlist
+	pidlist=""
+	log_mustnot $PGREP -fl $MKBUSY
 
-	case $dtst in
-		$CTR)	check_dataset datasetnonexists \
-					$CTR $FS $VOL $FSSNAP $VOLSNAP
-			if [[ $opt == *R* ]]; then
-				check_dataset datasetnonexists \
-					$FSCLONE $VOLCLONE
-			fi
-			;;
-		$FS)	check_dataset datasetexists $CTR $VOL
-			check_dataset datasetnonexists $FS
-			if [[ $opt != -f ]]; then
-				check_dataset datasetexists $VOLSNAP
+        if ! is_linux ; then
+		case $dtst in
+			$CTR)	check_dataset datasetnonexists \
+						$CTR $FS $VOL $FSSNAP $VOLSNAP
+				if [[ $opt == *R* ]]; then
+					check_dataset datasetnonexists \
+						$FSCLONE $VOLCLONE
+				fi
+				;;
+			$FS)	check_dataset datasetexists $CTR $VOL
+				check_dataset datasetnonexists $FS
+				if [[ $opt != -f ]]; then
+					check_dataset datasetexists $VOLSNAP
+					check_dataset datasetnonexists $FSSNAP
+				fi
+				if [[ $opt == *R* ]]; then
+					check_dataset datasetexists $VOLCLONE
+					check_dataset datasetnonexists $FSCLONE
+				fi
+				;;
+			$VOL)	check_dataset datasetexists $CTR $FS $FSSNAP
+				check_dataset datasetnonexists $VOL $VOLSNAP
+				if [[ $opt == *R* ]]; then
+					check_dataset datasetexists $FSCLONE
+					check_dataset datasetnonexists $VOLCLONE
+				fi
+				;;
+			$FSSNAP)
+				check_dataset datasetexists $CTR $FS $VOL $VOLSNAP
 				check_dataset datasetnonexists $FSSNAP
-			fi
-			if [[ $opt == *R* ]]; then
-				check_dataset datasetexists $VOLCLONE
-				check_dataset datasetnonexists $FSCLONE
-			fi
-			;;
-		$VOL)	check_dataset datasetexists $CTR $FS $FSSNAP
-			check_dataset datasetnonexists $VOL $VOLSNAP
-			if [[ $opt == *R* ]]; then
-				check_dataset datasetexists $FSCLONE
-				check_dataset datasetnonexists $VOLCLONE
-			fi
-			;;
-		$FSSNAP)
-			check_dataset datasetexists $CTR $FS $VOL $VOLSNAP
-			check_dataset datasetnonexists $FSSNAP
-			if [[ $opt == *R* ]]; then
-				check_dataset datasetexists $VOLCLONE
-				check_dataset datasetnonexists $FSCLONE
-			fi
-			;;
-		$VOLSNAP)
-			check_dataset datasetexists $CTR $FS $VOL $FSSNAP
-			check_dataset datasetnonexists $VOLSNAP
-			if [[ $opt == *R* ]]; then
-				check_dataset datasetexists $FSCLONE
-				check_dataset datasetnonexists $VOLCLONE
-			fi
-			;;
-	esac
+				if [[ $opt == *R* ]]; then
+					check_dataset datasetexists $VOLCLONE
+					check_dataset datasetnonexists $FSCLONE
+				fi
+				;;
+			$VOLSNAP)
+				check_dataset datasetexists $CTR $FS $VOL $FSSNAP
+				check_dataset datasetnonexists $VOLSNAP
+				if [[ $opt == *R* ]]; then
+					check_dataset datasetexists $FSCLONE
+					check_dataset datasetnonexists $VOLCLONE
+				fi
+				;;
+		esac
+	fi
 
 	log_note "'$ZFS destroy $opt $dtst' passed."
 }


### PR DESCRIPTION
…y_001_pos.ksh too linux.run.

The second part of the testcase attempts to verify that the -f option will succeed even when the dataset is busy. 
This behavior can't work under. Use "is_linux" to wrap the Linux specific changes, and add this testcase too linux.run.
