### PR TITLE
remove seq from zfs_receive_010.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
@@ -144,6 +144,11 @@ function test_n_check
 		*)	log_fail "Unsupported dataset: '$dtst'."
 	esac
 
+        # Kill any lingering instances of mkbusy, and clear the list.
+	[[ -z $pidlist ]] || log_must $KILL -TERM $pidlist
+	pidlist=""
+	log_mustnot $PGREP -fl $MKBUSY
+	
 	# Firstly, umount ufs filesystem which was created by zfs volume.
 	if is_global_zone; then
 		log_must $UMOUNT -f $TESTDIR1
@@ -151,11 +156,6 @@ function test_n_check
 
 	# Invoke 'zfs destroy [-rRf] <dataset>'
 	log_must $ZFS destroy $opt $dtst
-
-	# Kill any lingering instances of mkbusy, and clear the list.
-	[[ -z $pidlist ]] || log_must $KILL -TERM $pidlist
-	pidlist=""
-	log_mustnot $PGREP -fl $MKBUSY
 
 	case $dtst in
 		$CTR)	check_dataset datasetnonexists \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
@@ -21,7 +21,7 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, 2016 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -138,7 +138,7 @@ $RM $mntpnt/h17
 $RM $mntpnt2/h*
 
 # Add empty objects to $fs to exercise dmu_traverse code
-for i in `seq 1 100`; do
+for i in {1..100}; do
 	log_must touch $mntpnt/uf$i
 done
 


### PR DESCRIPTION
The zfs test "zfs_receive_010.ksh" script uses the "seq" GNU utility for a simple for loop. There's no need to rely on that dependency, so it should be removed/replaced.
This changes is remove from illumos request : 7262 remove seq from zfs_receive_010.ksh.
Link is:
https://github.com/illumos/illumos-gate/commit/b868f5d28c02403ad3cd322ee1635887f494ebe9
